### PR TITLE
Potential fix for code scanning alert no. 6: DOM text reinterpreted as HTML

### DIFF
--- a/immaculater/static/jquery.pjax.js
+++ b/immaculater/static/jquery.pjax.js
@@ -200,6 +200,7 @@ function pjax(options) {
   if (containerType !== 'string') {
     throw "expected string value for 'container' option; got " + containerType
   }
+  options.container = validateContainerSelector(options.container)
   var context = options.context = $(options.container)
   if (!context.length) {
     throw "the container selector '" + options.container + "' did not match anything"
@@ -675,6 +676,25 @@ function stripHash(location) {
 //   optionsFor('#container', {push: true})
 //   // => {container: '#container', push: true}
 //
+// Ensures a container value is a safe selector string and not HTML.
+function validateContainerSelector(container) {
+  if ($.type(container) !== 'string') {
+    throw "expected string value for 'container' option; got " + $.type(container)
+  }
+
+  var selector = $.trim(container)
+  if (!selector) {
+    throw "expected non-empty string value for 'container' option"
+  }
+
+  // Prevent jQuery from interpreting attacker-controlled input as HTML.
+  if (selector.indexOf('<') !== -1 || selector.indexOf('>') !== -1) {
+    throw "invalid container selector: must not contain HTML meta-characters"
+  }
+
+  return selector
+}
+
 //   optionsFor({container: '#container', push: true})
 //   // => {container: '#container', push: true}
 //


### PR DESCRIPTION
Potential fix for [https://github.com/lisagorewitdecker/immaculater/security/code-scanning/6](https://github.com/lisagorewitdecker/immaculater/security/code-scanning/6)

The best fix is to ensure `container` values from `data-pjax` are treated **only as selectors**, never as HTML strings. A minimal, behavior-preserving approach is to validate/reject unsafe container strings before calling `$()`.

Concretely in `immaculater/static/jquery.pjax.js`:
- Add a helper function that validates container selector input and rejects values that look like HTML (for example, containing `<` or `>`), and ensures the value is a non-empty string.
- Call this helper in `pjax(options)` after the existing type check and before `$(options.container)`.
- Keep existing behavior for valid selector strings unchanged.
- Throw an error for invalid/unsafe container values so unsafe input is not interpreted by jQuery.

This single change addresses all 3 variants because they all flow through `options.container` to line 203.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
