### PR TITLE
Potential fix for code scanning alert no. 5: Unsafe jQuery plugin

### DIFF
--- a/immaculater/static/jquery.pjax.js
+++ b/immaculater/static/jquery.pjax.js
@@ -201,7 +201,7 @@ function pjax(options) {
     throw "expected string value for 'container' option; got " + containerType
   }
   options.container = validateContainerSelector(options.container)
-  var context = options.context = $(options.container)
+  var context = options.context = $($.find(options.container))
   if (!context.length) {
     throw "the container selector '" + options.container + "' did not match anything"
   }


### PR DESCRIPTION
Potential fix for [https://github.com/lisagorewitdecker/immaculater/security/code-scanning/5](https://github.com/lisagorewitdecker/immaculater/security/code-scanning/5)

General fix: ensure `container` is always interpreted strictly as a CSS selector, never as HTML. For jQuery plugin safety, prefer selector-only APIs (`$.find`) before wrapping results.

Best targeted fix in `immaculater/static/jquery.pjax.js`:
- In `pjax(options)` around line 204, replace:
  - `var context = options.context = $(options.container)`
- With selector-only resolution:
  - `var context = options.context = $($.find(options.container))`

Why this is best:
- Preserves existing behavior (expects selector string; returns jQuery object context).
- Prevents accidental HTML parsing from untrusted `options.container`.
- Minimal, localized change; no import/dependency changes needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
