### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/todo/views.py
+++ b/todo/views.py
@@ -1406,8 +1406,8 @@ def _slackapi(request):
     return HttpResponse(u"\n".join(results['printed']) if results['printed'] else u'Command succeeded.',
                         content_type="text/plain")
   except immaculater.Error as error:
-    _debug_log(u'we have an error')
-    return HttpResponse(unicode(error), content_type="text/plain")
+    _debug_log(u'we have an error: %s' % unicode(error))
+    return HttpResponse(u'Command failed. Please try again.', content_type="text/plain")
 
 
 @never_cache


### PR DESCRIPTION
Potential fix for [https://github.com/lisagorewitdecker/immaculater/security/code-scanning/2](https://github.com/lisagorewitdecker/immaculater/security/code-scanning/2)

The fix is to stop returning `unicode(error)` to the client and instead return a generic error message, while preserving diagnostics by logging exception details on the server.

Best single fix in this snippet:
- In `todo/views.py`, inside `_slackapi`’s `except immaculater.Error as error:` block (around lines 1408–1410), replace the response body with a generic text like `"Command failed. Please try again."`.
- Keep `_debug_log` but include the exception text in server-side debug logging only, so functionality (visibility for developers) is preserved without exposing internals to users.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
