### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/todo/views.py
+++ b/todo/views.py
@@ -1385,7 +1385,8 @@ def api(request):
                          'printed': results['printed'],
                          'view': results['view']})
   except immaculater.Error as error:
-    return JsonResponse({'immaculater_error': unicode(error)}, status=422)
+    _debug_log(u'api command failed: %s' % unicode(error))
+    return JsonResponse({'error': 'Command failed. Please try again.'}, status=422)
 
 
 def _slackapi(request):

--- a/todo/views.py
+++ b/todo/views.py
@@ -1386,7 +1386,8 @@ def api(request):
                          'view': results['view']})
   except immaculater.Error as error:
     _debug_log(u'api command failed: %s' % unicode(error))
-    return JsonResponse({'error': 'Command failed. Please try again.'}, status=422)
+    return JsonResponse({'error': 'Command failed. Please try again.',
+                         'immaculater_error': 'Command failed. Please try again.'}, status=422)
 
 
 def _slackapi(request):


### PR DESCRIPTION
Potential fix for [https://github.com/lisagorewitdecker/immaculater/security/code-scanning/1](https://github.com/lisagorewitdecker/immaculater/security/code-scanning/1)

To fix this safely, do not return raw exception text to the client. Instead, log the detailed error server-side (for diagnostics) and return a generic, non-sensitive error message with the same status code.

Best single change in `todo/views.py` around lines 1387–1388:
- Keep the `except immaculater.Error as error:` block.
- Add a server-side log call containing `unicode(error)` (using existing `_debug_log` already used elsewhere in this file).
- Replace response payload from `{'immaculater_error': unicode(error)}` to a generic message such as `{'error': 'Command failed. Please try again.'}` with status `422`.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
